### PR TITLE
Use rawurlencode

### DIFF
--- a/developer-share-buttons.php
+++ b/developer-share-buttons.php
@@ -354,10 +354,10 @@ if ( ! class_exists( 'DeveloperShareButtons' ) ) {
 						$title .= ' ' . $url;
 					}
 
-					$url = urlencode( $url );
-					$title = urlencode( $title );
-					$text = urlencode( $text );
-					$image = urlencode( $image );
+					$url = rawurlencode( $url );
+					$title = rawurlencode( $title );
+					$text = rawurlencode( $text );
+					$image = rawurlencode( $image );
 
 					$share_text = apply_filters( static::$slug_ . '_share_text', $share_text );
 					$after_text = apply_filters( static::$slug_ . '_after_share_text', '', $service );


### PR DESCRIPTION
I'm not sure if this makes sense in all contexts. I developed an add-in share service to share the current page by email. The problem I found was that Apple's iOS email app doesn't handle `mailto:` urls with standard encoding -- all the spaces come out as `+` signs. 

Does changing the encoding to `rawurlencode` pose any problems for other services? Basically, the only difference is encoding spaces as `%20` instead of `+`...
